### PR TITLE
Place more filters on records list view

### DIFF
--- a/controllers/RecordsController.php
+++ b/controllers/RecordsController.php
@@ -29,9 +29,38 @@ class Neatline_RecordsController extends Neatline_Controller_Rest
      */
     public function listAction()
     {
-        echo Zend_Json::encode($this->_records->queryRecords(
-            $this->_request->getParams()
-        ));
+        $params = $this->_request->getParams();
+        foreach ($params as $key=>$val) {
+            switch ($key) {
+                case 'exhibit_id':
+                case 'zoom':
+                case 'limit':
+                case 'start': 
+                    $params[$key] = get_db()->quote($val, "INT");
+                    break;
+                case 'extent':
+                    # do nothing, extent is filtered elsewhere
+                    break;
+                case 'order':
+                    if (!in_array($val, array("id","owner_id","item_id","exhibit_id","added","modified",
+                                            "is_coverage","is_wms","slug","title","item_title","body",
+                                            "coverage","tags","widgets","presenter","fill_color",
+                                            "fill_color_select","stroke_color","stroke_color_select",
+                                            "fill_opacity","fill_opacity_select","stroke_opacity",
+                                            "stroke_opacity_select","stroke_width","point_radius",
+                                            "zindex","weight","start_date","end_date","after_date",
+                                            "before_date","point_image","wms_address","wms_layers",
+                                            "min_zoom","max_zoom","map_zoom","map_focus"))) {
+                        unset($params['order']);
+                    }
+                    break;
+                default:
+                    $params[$key] = get_db()->quote($val);
+                    break;
+            }
+        }
+        $results = $this->_records->queryRecords($params);
+        echo Zend_Json::encode($results);
     }
 
 

--- a/controllers/RecordsController.php
+++ b/controllers/RecordsController.php
@@ -36,12 +36,14 @@ class Neatline_RecordsController extends Neatline_Controller_Rest
                 case 'zoom':
                 case 'limit':
                 case 'start': 
+                    # quote as integer
                     $params[$key] = get_db()->quote($val, "INT");
                     break;
                 case 'extent':
-                    # do nothing, extent is filtered elsewhere
+                    # do nothing, extent is dealt with in the `filterExtent` function in `NeatlineRecordTable.php`
                     break;
                 case 'order':
+                    # ensure order is a valid column header, otherwise toss it
                     if (!in_array($val, array("id","owner_id","item_id","exhibit_id","added","modified",
                                             "is_coverage","is_wms","slug","title","item_title","body",
                                             "coverage","tags","widgets","presenter","fill_color",
@@ -54,7 +56,13 @@ class Neatline_RecordsController extends Neatline_Controller_Rest
                         unset($params['order']);
                     }
                     break;
+                case 'module':
+                case 'controller':
+                    # quote as varchar
+                    $params[$key] = get_db()->quote($val, "VARCHAR");
+                    break;
                 default:
+                    _log("Quoting text for key: $key", Zend_Log::INFO);
                     $params[$key] = get_db()->quote($val);
                     break;
             }


### PR DESCRIPTION
This view sends data from public-facing input to the database, and the order parameter in particular is vulnerable to SQL injection. It seems that within the context of the query, order needs to match one of the available column names, so I've made it so that those are the only parameters that are accepted. Any order parameter that isn't one of those is ignored, which prevents any malicious code from being executed.

Out of an abundance of caution, I've also quoted parameters that expect int values to a quote function for ints, and everything else besides the extent parameter gets quoted as a string. Extent gets map geometry data, and was vulnerable to sql injection prior to Neatline 2.6.3, but that is now validated at the point where the geometry is used.